### PR TITLE
Adding a Description to LED-RGB-CC-PTH

### DIFF
--- a/Ai_LED.lbr
+++ b/Ai_LED.lbr
@@ -310,12 +310,12 @@ Available from
 <package name="LED-RGB-PTH">
 <wire x1="2.5" y1="-1" x2="2.5" y2="1" width="0.127" layer="21"/>
 <wire x1="2.5" y1="-1" x2="2.5" y2="1" width="0.127" layer="21" curve="-316.397181"/>
-<pad name="2" x="0.635" y="0" drill="0.762" diameter="0.889" shape="long" rot="R90" stop="no"/>
-<pad name="1" x="1.905" y="0" drill="0.762" diameter="0.889" shape="long" rot="R90" stop="no"/>
-<pad name="3" x="-0.635" y="0" drill="0.762" diameter="0.889" shape="long" rot="R90" stop="no"/>
-<pad name="4" x="-1.905" y="0" drill="0.762" diameter="0.889" shape="long" rot="R90" stop="no"/>
-<text x="-3.175" y="3.175" size="1.27" layer="25" font="vector" ratio="15">&gt;NAME</text>
+<text x="3.175" y="-0.635" size="1.27" layer="25" font="vector" ratio="15">&gt;Name</text>
 <circle x="0.635" y="-1.5875" radius="0.254" width="0.127" layer="21"/>
+<pad name="1" x="1.905" y="0" drill="0.762" diameter="0.889" shape="long" rot="R90"/>
+<pad name="2" x="0.635" y="0" drill="0.762" diameter="0.889" shape="long" rot="R90"/>
+<pad name="3" x="-0.635" y="0" drill="0.762" diameter="0.889" shape="long" rot="R90"/>
+<pad name="4" x="-1.905" y="0" drill="0.762" diameter="0.889" shape="long" rot="R90"/>
 </package>
 </packages>
 <symbols>
@@ -498,10 +498,10 @@ Available from
 <wire x1="-3.81" y1="6.35" x2="-3.81" y2="-6.35" width="0.254" layer="94" style="shortdash"/>
 </symbol>
 <symbol name="LED-RGB-CC-PTH">
-<pin name="RED_CATHODE" x="-7.62" y="5.08" visible="off" length="middle"/>
-<pin name="GREEN_CATHODE" x="-7.62" y="0" visible="off" length="middle"/>
-<pin name="BLUE_CATHODE" x="-7.62" y="-5.08" visible="off" length="middle"/>
-<pin name="CATHODE" x="7.62" y="0" visible="off" length="middle" rot="R180"/>
+<pin name="RED_CATHODE" x="-7.62" y="5.08" visible="off" length="middle" direction="pas"/>
+<pin name="GREEN_CATHODE" x="-7.62" y="0" visible="off" length="middle" direction="pas"/>
+<pin name="BLUE_CATHODE" x="-7.62" y="-5.08" visible="off" length="middle" direction="pas"/>
+<pin name="CATHODE" x="7.62" y="0" visible="off" length="middle" direction="pas" rot="R180"/>
 <wire x1="-2.54" y1="6.604" x2="-2.54" y2="3.556" width="0.254" layer="94"/>
 <wire x1="-2.54" y1="3.556" x2="0" y2="5.08" width="0.254" layer="94"/>
 <wire x1="0" y1="5.08" x2="-2.54" y2="6.604" width="0.254" layer="94"/>
@@ -525,7 +525,7 @@ Available from
 <wire x1="2.54" y1="5.08" x2="0" y2="5.08" width="0.1524" layer="94"/>
 <wire x1="2.54" y1="0" x2="0" y2="0" width="0.1524" layer="94"/>
 <wire x1="2.54" y1="-5.08" x2="0" y2="-5.08" width="0.1524" layer="94"/>
-<text x="-4.826" y="-8.636" size="1.524" layer="95" font="vector" ratio="15">&gt;NAME</text>
+<text x="-4.064" y="-8.636" size="1.524" layer="95" font="vector" ratio="15">&gt;NAME</text>
 </symbol>
 </symbols>
 <devicesets>
@@ -641,7 +641,11 @@ A 5x5mm SMD LED with built-in controller IC.</description>
 </device>
 </devices>
 </deviceset>
-<deviceset name="LED-RGB-CC-PTH">
+<deviceset name="LED-RGB-CC-PTH" prefix="LED">
+<description>&lt;p&gt;5mm RGB LED (Common Cathode; Clear)&lt;/p&gt;
+&lt;p&gt;Acrobotic part: led-00013&lt;/p&gt;
+&lt;p&gt;http://acrobotic.com/led-00013.html&lt;/p&gt;
+&lt;p&gt;&lt;b&gt;NOTE:&lt;/b&gt; For the board layout, modify your DRC Restring Pads to a min. of 6mil or less and at 20% or less. &lt;/p&gt;</description>
 <gates>
 <gate name="G$1" symbol="LED-RGB-CC-PTH" x="0" y="0"/>
 </gates>


### PR DESCRIPTION
Description added:
5mm RGB LED (Common Cathode; Clear)

Acrobotic part: led-00013

http://acrobotic.com/led-00013.html

NOTE: For the board, modify your DRC Restring Pads to a min. of 6mil or
less and at 20% or less.
